### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,8 @@ potool (0.19-2) UNRELEASED; urgency=medium
   * Set debhelper-compat version in Build-Depends.
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.5.0, no changes needed.
+  * Remove constraints unnecessary since stretch:
+    + potool: Drop versioned constraint on poedit in Breaks.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:35:28 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Homepage: http://marcin.owsiany.pl/potool-page
 Package: potool
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, sensible-utils
-Breaks: poedit (<< 1.0.3-2)
 Description: program to aid manipulation of gettext po files
  This package contains the filter program 'potool', as well
  as a few helper scripts:


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/potool/4dd99106-e05e-4bda-9527-5fced0af9862.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/bd/37518c359c4477b900a45a804bb78e16181918.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/cf/0f3bc00b726e4772219fcb90fa92e95cc4dabf.debug
### Control files of package potool: lines which differ (wdiff format)
* [-Breaks: poedit (<< 1.0.3-2)-]
### Control files of package potool-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-cf0f3bc00b726e4772219fcb90fa92e95cc4dabf-] {+bd37518c359c4477b900a45a804bb78e16181918+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4dd99106-e05e-4bda-9527-5fced0af9862/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4dd99106-e05e-4bda-9527-5fced0af9862/diffoscope)).
