### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ potool (0.19-2) UNRELEASED; urgency=medium
   * Update standards version to 4.5.0, no changes needed.
   * Remove constraints unnecessary since stretch:
     + potool: Drop versioned constraint on poedit in Breaks.
+  * Update watch file format version to 4.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:35:28 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,7 @@ potool (0.19-2) UNRELEASED; urgency=medium
     + potool: Drop versioned constraint on poedit in Breaks.
   * Update watch file format version to 4.
   * Use secure URI in Homepage field.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:35:28 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,7 @@ potool (0.19-2) UNRELEASED; urgency=medium
   * Update watch file format version to 4.
   * Use secure URI in Homepage field.
   * Bump debhelper from old 12 to 13.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:35:28 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ potool (0.19-2) UNRELEASED; urgency=medium
   * Remove constraints unnecessary since stretch:
     + potool: Drop versioned constraint on poedit in Breaks.
   * Update watch file format version to 4.
+  * Use secure URI in Homepage field.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 07:35:28 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: potool
 Section: utils
 Priority: optional
 Maintainer: Marcin Owsiany <porridge@debian.org>
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Build-Depends: libglib2.0-dev, bison, flex, debhelper-compat (= 13), rename
 Vcs-Git: https://github.com/porridge/potool.git -b debian
 Vcs-Browser: https://github.com/porridge/potool/tree/debian

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 4.5.0
 Build-Depends: libglib2.0-dev, bison, flex, debhelper-compat (= 12), rename
 Vcs-Git: https://github.com/porridge/potool.git -b debian
 Vcs-Browser: https://github.com/porridge/potool/tree/debian
-Homepage: http://marcin.owsiany.pl/potool-page
+Homepage: https://marcin.owsiany.pl/potool-page
 
 Package: potool
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Marcin Owsiany <porridge@debian.org>
 Standards-Version: 4.5.0
-Build-Depends: libglib2.0-dev, bison, flex, debhelper-compat (= 12), rename
+Build-Depends: libglib2.0-dev, bison, flex, debhelper-compat (= 13), rename
 Vcs-Git: https://github.com/porridge/potool.git -b debian
 Vcs-Browser: https://github.com/porridge/potool/tree/debian
 Homepage: https://marcin.owsiany.pl/potool-page

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
-version=3
+version=4
 http://marcin.owsiany.pl/potool.en.html potool/potool-(\d[^[:space:]]*)\.(?:tar\.gz|tgz|tar\.bz2|tbz|tbz2)


### PR DESCRIPTION
Fix some issues reported by lintian

* Update watch file format version to 4. ([older-debian-watch-file-standard](https://lintian.debian.org/tags/older-debian-watch-file-standard))

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/potool/969d0e80-04c9-4b6d-8b0c-7a1d6ea4339c.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package potool: lines which differ (wdiff format)
* Homepage: [-http&#8203;://marcin.owsiany.pl/potool-page-] {+https&#8203;://marcin.owsiany.pl/potool-page+}

No differences were encountered between the control files of package \*\*potool-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/969d0e80-04c9-4b6d-8b0c-7a1d6ea4339c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/969d0e80-04c9-4b6d-8b0c-7a1d6ea4339c/diffoscope)).
